### PR TITLE
Fix timeouts on failed tests when running in Mocha

### DIFF
--- a/src/wait-for-update.js
+++ b/src/wait-for-update.js
@@ -13,7 +13,7 @@ import Vue from 'vue'
 // .then(() => {
 //   // more assertions...
 // })
-// .then(done)
+// .end(done)
 
 export default initialCb => {
   let end
@@ -29,7 +29,9 @@ export default initialCb => {
         hasError = true
         const done = queue[queue.length - 1]
         if (done && done.fail) {
-          done.fail(e)
+          done.fail(e) // Jasmine behaviour
+        } else if (done) {
+          done(e) // Mocha behaviour
         }
       }
       if (!hasError && !job.wait) {
@@ -44,7 +46,7 @@ export default initialCb => {
 
   Vue.nextTick(() => {
     if (!queue.length || (!end && !queue[queue.length - 1].fail)) {
-      throw new Error('waitForUpdate chain is missing .then(done)')
+      throw new Error('waitForUpdate chain is missing .end(done)')
     }
     shift()
   })


### PR DESCRIPTION
When using waitForUpdate under Mocha, test failure results in timeout as Mocha `done` does not use `done.fail(e)`. Instead, Mocha just calls `done(e)` with the error. Update to try that if `done.fail` is not present.
Additionally fixes the slight documentation issue with an incomplete chain complaining that `then(done)` is missing when it should be `end(done)`.