### PR TITLE
Implement provide in mount with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Unlike other component testing libraries, VueUnit does not focus on DOM traversa
     * [Component with events](#component-with-events)
     * [Component with default slot](#component-with-default-slot)
     * [Component with multiple slots](#component-with-multiple-slots)
+    * [Component with injects](#component-with-injects)
   * [Options Object](#options-object)
   * [`shallow()`](#shallow)
   * [`build()` and `buildShallow()`](#build-and-build-shallow)
@@ -152,10 +153,30 @@ const ComponentWithMultipleSlots = {
     </div>
   `
 }
-  
+
 it('sets content for multiple slots', () => {
   mount(ComponentWithMultipleSlots, {}, {}, { default: 'Hello World', foo: '<p>Bar</p>' })
   expect($('.component')).to.have.html('Hello World <p>Bar</p>')
+})
+```
+
+The 4th argument `mount()` accepts is an object with values available to be injected via the provide/inject behaviour. It is equivalent to defining `provide` on an ancestor component.
+
+#### <a name="component-with-injects"></a>Component with injects
+
+```js
+const ComponentWithInjects = {
+  template: `
+    <div class="component">
+      Hello {{ message }}
+    </div>
+  `,
+  inject: ['message']
+}
+
+it('provides values to be injected', () => {
+  mount(ComponentWithInjects, {}, {}, {}, { message: 'World' })
+  expect($('.component')).to.have.text('Hello World')
 })
 ```
 
@@ -169,20 +190,23 @@ const ComponentWithAllOptions = {
       <slot name="foo"></slot>
     </div>
   `,
-  props: ['message']
+  props: ['message'],
+  inject: ['messageFromAncestor']
 }
-  
+
 it('uses an options object', () => {
   const listener = sinon.spy()
   const options = {
     props: { message: 'bar' },
     on: { foo: listener },
-    slots: { default: 'Hello World', foo: '<p>Bar</p>' }
+    slots: { default: 'Hello World', foo: '<p>Bar</p>' },
+    provide: { messageFromAncestor, 'bar' }
   }
-  mount(ComponentWithAllOptions, options)
+  vm = mount(ComponentWithAllOptions, options)
   expect($('.component')).to.have.html('Hello World <p>Bar</p>')
   simulate($('.component'), 'click')
   expect(listener).to.have.been.calledWith('bar')
+  expect(vm.messageFromAncestor).to.equal('bar')
 })
 ```
 
@@ -191,12 +215,13 @@ it('uses an options object', () => {
 | `props` | `{}` | `Object` | An object containing camelCased props to be passed to the component |
 | `on` | `{}` | `Object` | An object containing listeners to be called when an event is trigger by the component |
 | `slots` | `{}` | `Object` or `String` | String containing the template for the `default` slot of the component. Objects containing templates for slots (should be keyed by the slot name).
+| `provide` | `{}` | `Object` | An object simulating values given from parent components via Vue's `provide`. Available to the equivalent `inject` component property.
 
 ### <a name="shallow"></a>`shallow()`
 
 The `shallow()` function has the same signature as the `mount()` function, however it will shallow render the component by replacing any **locally registered** child components with an empty kebab-cased tag of their name.
 
-This enables you to test higher-level components without the concern of the required props or dependencies of nested child components. 
+This enables you to test higher-level components without the concern of the required props or dependencies of nested child components.
 
 For example:
 

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export function mount (component, props = {}, on = {}, slots = {}, provide = {},
 }
 
 function isOptions (object) {
-  return ('props' in object || 'event' in object || 'slots' in object || 'provide' in object)
+  return ('props' in object || 'on' in object || 'slots' in object || 'provide' in object)
 }
 
 function createSlots (slots, h) {

--- a/src/index.js
+++ b/src/index.js
@@ -9,23 +9,27 @@ let mountedInstances = []
 let actions = {}
 let getters = {}
 
-export function mount (component, props = {}, on = {}, slots = {}, callback) {
+export function mount (component, props = {}, on = {}, slots = {}, provide = {}, callback) {
   if (arguments.length === 2 && typeof props === 'function') {
-    return mount(component, {}, {}, {}, props)
+    return mount(component, {}, {}, {}, {}, props)
   }
 
   if (arguments.length <= 3 && isOptions(props)) {
     const cb = typeof on === 'function' ? on : undefined
-    return mount(component, props.props, props.on, props.slots, cb)
+    return mount(component, props.props, props.on, props.slots, props.provide, cb)
   }
 
-  if (!isOptions(props) && arguments.length < 5 && typeof arguments[arguments.length - 1] === 'function') {
+  if (!isOptions(props) && arguments.length < 6 && typeof arguments[arguments.length - 1] === 'function') {
     if (typeof on === 'function') {
-      return mount(component, props, {}, {}, on)
+      return mount(component, props, {}, {}, {}, on)
     }
     /* istanbul ignore else */
     if (typeof slots === 'function') {
-      return mount(component, props, on, {}, slots)
+      return mount(component, props, on, {}, {}, slots)
+    }
+    /* istanbul ignore else */
+    if (typeof provide === 'function') {
+      return mount(component, props, on, slots, {}, provide)
     }
   }
 
@@ -36,7 +40,8 @@ export function mount (component, props = {}, on = {}, slots = {}, callback) {
     render: h => h(
       component,
       { props, on },
-      createSlots(slots, h))
+      createSlots(slots, h)),
+    provide: provide
   }
   const store = buildFakeStore()
 
@@ -60,7 +65,7 @@ export function mount (component, props = {}, on = {}, slots = {}, callback) {
 }
 
 function isOptions (object) {
-  return ('props' in object || 'event' in object || 'slots' in object)
+  return ('props' in object || 'event' in object || 'slots' in object || 'provide' in object)
 }
 
 function createSlots (slots, h) {

--- a/test/specs/mount.spec.js
+++ b/test/specs/mount.spec.js
@@ -76,6 +76,21 @@ describe('mount', () => {
     expect(callMount).to.throw(Error, 'Error when rendering default slot')
   })
 
+  it('mounts a component with provided dependencies', () => {
+      const ComponentWithInjects = {
+        template: '<div>Hello {{ valueFromInject }}</div>',
+        inject: ['providedValue'],
+        data () {
+          return {
+            valueFromInject: this.providedValue
+          }
+        }
+      }
+      const vm = mount(ComponentWithInjects, { provide: { providedValue: 'World' } })
+      expect(vm.$el.textContent).to.equal('Hello World')
+      expect(vm.providedValue).to.equal('World')
+  })
+
   it('receives an optional callback which is passed the vm after mounting', () => {
     const mounted = sinon.spy()
     const callback = sinon.spy()
@@ -103,7 +118,8 @@ describe('mount', () => {
     const options = {
       props: { message: 'Hello ' },
       on: { click },
-      slots: { default: '<span>World</span>' }
+      slots: { default: '<span>World</span>' },
+      provide: { injectedValue: 'test' }
     }
     const vm = mount(ComponentWithAllOptions, options)
     expect(vm.$el.innerHTML).to.equal('Hello <span>World</span>')


### PR DESCRIPTION
Vue 2.2 adds the [provide/inject feature](https://vuejs.org/v2/api/#provide-inject) for a form of component-level dependency injection. This PR allows for stubbing provides in `mount()` by adding another argument. Also contains a couple of tests and follows the existing conventions for argument handling. Should not be a breaking change.

Usage examples: 
```
mount(ComponentName, {}, {}, {}, { providedThing: 'value' })
mount(ComponentName, { provide: { providedThing: 'value' } }, optionalCallback)
```